### PR TITLE
Issue 32 deploy ingress nginx

### DIFF
--- a/pulumi/folio/index.ts
+++ b/pulumi/folio/index.ts
@@ -66,7 +66,7 @@ const sg = new aws.ec2.SecurityGroup(sgName, {
     description: "Security group for FOLIO EKS cluster.",
     vpcId: vpc.id,
     ingress: [{
-        description: "Allow inbound traffic on 443",
+        description: "Allow inbound traffic on 80",
         fromPort: 80,
         toPort: 80,
         protocol: "tcp",
@@ -99,7 +99,7 @@ const sg = new aws.ec2.SecurityGroup(sgName, {
 const managedPolicyArns: string[] = [
     "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
     "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
-    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 ];
 
 // Creates a role and attaches the EKS worker node IAM managed policies.
@@ -207,9 +207,9 @@ new aws.eks.Addon(corednsName, {
 // This is just an example of a deployment that we can do. As we move forward
 // we would have one service and deployment for okapi, one for the stripes container,
 // and one for any additional containers that require special ports, like edgeconnexion.
-const appName = "folio";
+const appName = "test-nginx";
 const appLabels = { appClass: appName };
-new k8s.apps.v1.Deployment(`${appName}-nginx-dep`, {
+new k8s.apps.v1.Deployment(`${appName}-dep`, {
     metadata: { labels: appLabels },
     spec: {
         replicas: 2,

--- a/pulumi/folio/index.ts
+++ b/pulumi/folio/index.ts
@@ -204,7 +204,9 @@ new aws.eks.Addon(corednsName, {
     addonName: "coredns",
 });
 
-// Deploy nginx.
+// This is just an example of a deployment that we can do. As we move forward
+// we would have one service and deployment for okapi, one for the stripes container,
+// and one for any additional containers that require special ports, like edgeconnexion.
 const appName = "folio";
 const appLabels = { appClass: appName };
 new k8s.apps.v1.Deployment(`${appName}-nginx-dep`, {
@@ -225,9 +227,11 @@ new k8s.apps.v1.Deployment(`${appName}-nginx-dep`, {
     },
 }, { provider: cluster.provider });
 
-const service = new k8s.core.v1.Service(`${appName}-alb-svc`, {
+// This deploys what is an ELB or "classic" load balancer.
+const service = new k8s.core.v1.Service(`${appName}-elb-svc`, {
     metadata: { labels: appLabels },
     spec: {
+        // This creates an AWS ELB for us.
         type: "LoadBalancer",
         ports: [{ port: 80, targetPort: "http" }],
         selector: appLabels,


### PR DESCRIPTION
I'd like to try to make the argument that we don't have a need for Level 7 load balancers, and in fact will get more benefits from Level 4. Some background:

* ELB - This is AWS's "classic" load balancing product. It has been out for 10 years or so. This is Level 4.
* ALB - This is the newer product with more features. This is Level 7.

I don't think we need the features of ALBs and in fact have a need for some of the features of ELBs, and the simplicity of ELBs is also a big benefit. Here are some articles covering the differences. I'm not seeing a use case for us for any of the benefits.
* https://www.sumologic.com/blog/aws-elb-alb/
* https://www.giantswarm.io/blog/load-balancer-service-use-cases-on-aws

This pull request shows how easy it would be to do a Level 4 ELB with EKS. You do it entirely with services. When you configure a service of type `LoadBalancer` it automatically creates an ELB for you. Setting up an ALB is more complicated, even with pulumi. You have to worry about things like `TargetGroups` which have already given us many headaches. Here is a [code example](https://github.com/pulumi/pulumi-kubernetes-ingress-nginx/blob/master/examples/simple-nginx-ts/index.ts) of doing that in pulumi.

Here my reasons for why I think L4 is the way to go:
* It's easy to set up and test. Just deploy a service, and you get an elb url that you can test immediately. No need to worry about targets.
* We need the flexibility of opening up certain services to certain ports, like for the edge modules.
* The default nginx controller that ships with ALB only does 80/443 so we'll be stuck back in that situation again.
* I think it should be easier to bind a cert to.
* It should be easier to map a custom domain to. It's just a one-to-one map forward of the custom domain to the ELB. Nothing special needs to happen in between.

As a footnote I think that the reason we had trouble getting the edge-connexion stuff on the last go-round to work was that we were trying to do both an ALB and an ELB at the same time which just didn't work. It was also because eks was automatically creating an ELB for us, when we thought we needed to manually create one.