### PR TITLE
Issue 66 prepare folio for larger data loads

### DIFF
--- a/pulumi/folio/classes/FolioModule.ts
+++ b/pulumi/folio/classes/FolioModule.ts
@@ -47,6 +47,9 @@ export class FolioModule {
         } else if (name.startsWith("mod-permissions")) {
             this.limitsMemory = "1500Mi"
             this.requestsMemory = "500Mi";
+        } else if (name.startsWith("mod-inventory-storage")) {
+            this.limitsMemory = "1500Mi"
+            this.requestsMemory = "500Mi";
         } else {
             this.limitsMemory = "512Mi"
             this.requestsMemory = "400Mi";

--- a/pulumi/folio/classes/FolioModule.ts
+++ b/pulumi/folio/classes/FolioModule.ts
@@ -48,6 +48,8 @@ export class FolioModule {
             this.limitsMemory = "1500Mi"
             this.requestsMemory = "500Mi";
         } else if (name.startsWith("mod-inventory-storage")) {
+            // mod-inventory storage will crash with OOM during data import if its
+            // memory limit isn't increased.
             this.limitsMemory = "1500Mi"
             this.requestsMemory = "500Mi";
         } else {

--- a/pulumi/folio/scripts/email-setup.sh
+++ b/pulumi/folio/scripts/email-setup.sh
@@ -1,0 +1,98 @@
+# Configures FOLIO email sending to use AWS SES (simple email service) as the SMTP
+# host. This requires that SES be set up through the console (it has likely already
+# been done so check that first).
+
+# Note this is not idempotent. Once the config entries are there, they have to
+# be updated with the config entry id. See update-config.sh for help with that.
+# See https://github.com/folio-org/mod-configuration/blob/master/ramls/configuration/config.raml
+
+# This script requires that you have set the following in your environment:
+# - SMTP_PASSWORD
+# - SMTP_USERNAME
+# - TOKEN
+
+# You can get a token by going to /settings/developer in the folio UI.
+# Ask a colleague how to get the SMTP username and password.
+
+OKAPI="https://folio-iris-okapi.cublcta.com:9130"
+CONFIGS=$(cat <<EOF
+[
+    {
+        "module": "SMTP_SERVER",
+        "configName": "smtp",
+        "code": "EMAIL_SMTP_HOST",
+        "description": "Server smtp host",
+        "default": true,
+        "enabled": true,
+        "value": "email-smtp.us-west-2.amazonaws.com"
+    },
+    {
+        "module": "SMTP_SERVER",
+        "configName": "smtp",
+        "code": "EMAIL_USERNAME",
+        "description": "SMTP Username",
+        "default": true,
+        "enabled": true,
+        "value": ""
+    },
+    {
+        "module": "SMTP_SERVER",
+        "configName": "smtp",
+        "code": "EMAIL_PASSWORD",
+        "description": "SMTP Password",
+        "default": true,
+        "enabled": true,
+        "value": "$SMTP_PASSWORD"
+    },
+    {
+        "module": "SMTP_SERVER",
+        "configName": "smtp",
+        "code": "EMAIL_SMTP_PORT",
+        "description": "Server smtp port",
+        "default": true,
+        "enabled": true,
+        "value": "587"
+    },
+    {
+        "module": "SMTP_SERVER",
+        "configName": "smtp",
+        "code": "EMAIL_FROM",
+        "description": "SMTP From Email Address",
+        "default": true,
+        "enabled": true,
+        "value": "libnotify@colorado.edu"
+    },
+    {
+        "module": "SMTP_SERVER",
+        "configName": "smtp",
+        "code": "EMAIL_SMTP_SSL",
+        "description": "SMTP SSL configuration",
+        "default": true,
+        "enabled": true,
+        "value": "STARTTLS"
+    },
+    {
+        "module": "USERSBL",
+        "configName": "resetPassword",
+        "code": "FOLIO_HOST",
+        "description": "Folio UI application host",
+        "default": true,
+        "enabled": true,
+        "value": "$OKAPI"
+    }
+]
+EOF
+)
+
+# Read the above JSON into a here-doc, using jq to read each json object.
+# Then post each to the config endpoint.
+jq -c '.[]'  <<< "$CONFIGS" | while read i; do
+    echo Posting $i to $OKAPI
+    curl -X POST \
+    $OKAPI/configurations/entries \
+    -H 'Content-Type: application/json' \
+    -H 'X-Okapi-Tenant: cubl' \
+    -H "X-Okapi-Token: $TOKEN" \
+    -d "$i" \
+    -v
+done

--- a/pulumi/folio/scripts/email-update-host.sh
+++ b/pulumi/folio/scripts/email-update-host.sh
@@ -1,0 +1,28 @@
+# This script requires that you have set the following in your environment:
+# - TOKEN
+
+# You can get a token by going to /settings/developer in the folio UI.
+
+# See get-configs.sh for how to get the entry id for a given deployment.
+ENTRY_ID="0cabf10f-57f7-4ab0-9cdb-24fba5a68802"
+OKAPI="https://folio-iris-okapi.cublcta.com:9130"
+CONFIG=$(cat <<EOF
+    {
+        "module": "SMTP_SERVER",
+        "configName": "smtp",
+        "code": "EMAIL_SMTP_HOST",
+        "description": "Server smtp host",
+        "default": true,
+        "enabled": true,
+        "value": "email-smtp.us-west-2.amazonaws.com"
+    }
+EOF
+)
+
+curl -X PUT \
+$OKAPI/configurations/entries/$ENTRY_ID \
+-H 'Content-Type: application/json' \
+-H 'X-Okapi-Tenant: cubl' \
+-H "X-Okapi-Token: $TOKEN" \
+-d "$CONFIG" \
+-v

--- a/pulumi/folio/scripts/email-update-password.sh
+++ b/pulumi/folio/scripts/email-update-password.sh
@@ -1,0 +1,29 @@
+# This script requires that you have set the following in your environment:
+# - TOKEN
+# - SMTP_PASSWORD
+
+# You can get a token by going to /settings/developer in the folio UI.
+
+# See get-configs.sh for how to get the entry id for a given deployment.
+ENTRY_ID="7a572299-e0db-4aca-98d3-8a6e6709a9cb"
+OKAPI="https://folio-iris-okapi.cublcta.com:9130"
+CONFIG=$(cat <<EOF
+    {
+        "module": "SMTP_SERVER",
+        "configName": "smtp",
+        "code": "EMAIL_PASSWORD",
+        "description": "SMTP Password",
+        "default": true,
+        "enabled": true,
+        "value": "$SMTP_PASSWORD"
+    }
+EOF
+)
+
+curl -X PUT \
+$OKAPI/configurations/entries/$ENTRY_ID \
+-H 'Content-Type: application/json' \
+-H 'X-Okapi-Tenant: cubl' \
+-H "X-Okapi-Token: $TOKEN" \
+-d "$CONFIG" \
+-v

--- a/pulumi/folio/scripts/email-update-reset.sh
+++ b/pulumi/folio/scripts/email-update-reset.sh
@@ -1,0 +1,32 @@
+# This will update the reset url for 
+
+# This script requires that you have set the following in your environment:
+# - TOKEN
+
+# You can get a token by going to /settings/developer in the folio UI.
+
+# See get-configs.sh for how to get the entry id for a given deployment.
+ENTRY_ID="f78111a8-d8a7-4809-a09b-c4f6091ec18c"
+OKAPI="https://folio-iris-okapi.cublcta.com:9130"
+# This is not OKAPI but the route for stripes. Very important.
+RESET_URL="https://folio-iris.cublcta.com"
+CONFIG=$(cat <<EOF
+    {
+        "module": "USERSBL",
+        "configName": "resetPassword",
+        "code": "FOLIO_HOST",
+        "description": "Folio UI application host",
+        "default": true,
+        "enabled": true,
+        "value": "$RESET_URL"
+    }
+EOF
+)
+
+curl -X PUT \
+$OKAPI/configurations/entries/$ENTRY_ID \
+-H 'Content-Type: application/json' \
+-H 'X-Okapi-Tenant: cubl' \
+-H "X-Okapi-Token: $TOKEN" \
+-d "$CONFIG" \
+-v

--- a/pulumi/folio/scripts/email-update-user.sh
+++ b/pulumi/folio/scripts/email-update-user.sh
@@ -1,0 +1,29 @@
+# This script requires that you have set the following in your environment:
+# - TOKEN
+# - SMTP_USERNAME
+
+# You can get a token by going to /settings/developer in the folio UI.
+
+# See get-configs.sh for how to get the entry id for a given deployment.
+ENTRY_ID="0fc409b8-fb03-4e9e-b348-ec741da8b3f4"
+OKAPI="https://folio-iris-okapi.cublcta.com:9130"
+CONFIG=$(cat <<EOF
+    {
+        "module": "SMTP_SERVER",
+        "configName": "smtp",
+        "code": "EMAIL_USERNAME",
+        "description": "SMTP Username",
+        "default": true,
+        "enabled": true,
+        "value": "$SMTP_USERNAME"
+    }
+EOF
+)
+
+curl -X PUT \
+$OKAPI/configurations/entries/$ENTRY_ID \
+-H 'Content-Type: application/json' \
+-H 'X-Okapi-Tenant: cubl' \
+-H "X-Okapi-Token: $TOKEN" \
+-d "$CONFIG" \
+-v

--- a/pulumi/folio/scripts/get-configs.sh
+++ b/pulumi/folio/scripts/get-configs.sh
@@ -1,0 +1,15 @@
+# This script requires that you have set the following in your environment:
+# - TOKEN
+
+# You can get a token by going to /settings/developer in the folio UI.
+
+OKAPI="https://folio-iris-okapi.cublcta.com:9130"
+
+# Read the above JSON into a here-doc, using jq to read each json object.
+# Then post each to the config endpoint.
+curl \
+$OKAPI/configurations/entries \
+-H 'Content-Type: application/json' \
+-H 'X-Okapi-Tenant: cubl' \
+-H "X-Okapi-Token: $TOKEN" \
+-v


### PR DESCRIPTION
This addresses two issues that have emerged with the new infrastructure:

* Noticed that folio-helm's mod-authtoken was [hard-coding the token salt](https://github.com/folio-org/folio-helm/blob/1f11f54ade1b00eff92427b549764a73e7ec21bf/mod-authtoken/values.yaml#L83).
* mod-inventory-storage's deployment was crashing with OOM.
* Scripts for email setup and update.

Both of these changes have been deployed and tested.