### PR TITLE
Exporting the cluster role ARN into the stack state

### DIFF
--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -159,10 +159,6 @@ At this point all you'll need to do is register your modules to your tenant and 
 
 2. Assuming a role. You should consider doing this in a separate terminal session because Pulumi uses your AWS credentials and `kubectl` needs to use the assumed role.
 
-    TODO Export the role name so that it's in the stack state.
-
-    TODO Explain how to get the role name from pulumi.
-
     If you didn't create the cluster you'll need to assume the role associated with it. You need to get the role ARN. Do this by running the following command for the current stack:
 
     ```sh

--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -163,11 +163,10 @@ At this point all you'll need to do is register your modules to your tenant and 
 
     TODO Explain how to get the role name from pulumi.
 
-    If you didn't create the cluster you'll need to assume the role associated with it. You need to get the role ARN.
+    If you didn't create the cluster you'll need to assume the role associated with it. You need to get the role ARN. Do this by running the following command for the current stack:
 
     ```sh
-    aws iam list-roles
-    # In the response use `/folio-cluster-admin-role` to find the associated role and note the `Arn`
+    pulumi stack output folioClusterAdminRoleArn
     ```
 
     Now assume the role:

--- a/pulumi/folio/index.ts
+++ b/pulumi/folio/index.ts
@@ -160,6 +160,8 @@ const folioInstanceProfile =
 // See the readme file for how this is done.
 const folioClusterAdminRoleName = "folio-cluster-admin-role";
 const folioClusterAdminRole = iam.deploy.awsRBACRole(folioClusterAdminRoleName, tags);
+// Run pulumi stack output folioClusterAdminRoleArn to get this arn in the console.
+export const folioClusterAdminRoleArn = folioClusterAdminRole.arn;
 
 // Create an EKS cluster.
 const folioClusterName = "folio-cluster";


### PR DESCRIPTION
This makes it available via pulumi stack output. This is easier than
listing the iam roles in the aws command line tools since you can't tell
which one is your cluster there. This way you'll get exactly the cluster
role's ARN you need.