### PR TITLE
Update test Folio URL

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ About FOLIO
 Welcome to the FOLIO documentation wiki! FOLIO is the LSP for the CU Boulder and CU Law Libraries.
 
 * Our current version is **Iris**
-* Our current sandbox environment: `folio.colorado.edu <https://folio.colorado.edu>`_
+* Our current sandbox environment: `cu-test.folio.indexdata.com <https://cu-test.folio.indexdata.com/>`_
 * Chrome is the recommended browser for FOLIO
 
 To get appropriate user permissions to FOLIO please put in a `ServiceNow ticket <https://colorado.service-now.com/lib_landing.do>`_ with Libraries Specific Applications and Technology


### PR DESCRIPTION
The CTA hosted Folio is no longer available.  All users should be directed to the test Folio url provided by Index Data